### PR TITLE
remove fastercsv and use csv

### DIFF
--- a/csv2lighthouse.rb
+++ b/csv2lighthouse.rb
@@ -5,7 +5,7 @@ require 'activerecord'
 require 'activesupport'
 require 'activeresource'
 require 'lighthouse'
-require 'fastercsv'
+require 'csv'
 
 # Configure Me... #####################################################
  
@@ -35,7 +35,7 @@ def taggify(s)
 end
 
 def import(fname)
-  FasterCSV.foreach(fname, :headers => :first_row) do |row|
+  CSV.foreach(fname, :headers => :first_row) do |row|
     save_to_lighthouse(row)
   end
 end


### PR DESCRIPTION
FasterCSV is giving error with ruby 1.9 and 2.0 instead use CSV .
